### PR TITLE
Deprecate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This module contains the dashboard and its related components for the Merchant portal.
 
+**DEPRECATED - This module is not continued at this point.**
+
 ## Installation
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,5 @@
   "config": {
     "sort-packages": true
   },
-  "abandoned": true
+  "abandoned": "spryker/dashboard-merchant-portal-gui"
 }

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,6 @@
   },
   "config": {
     "sort-packages": true
-  }
+  },
+  "abandoned": true
 }


### PR DESCRIPTION
Auto created via release app as merge-only after removing from nonsplit core.